### PR TITLE
Make #terraform no longer be private

### DIFF
--- a/lib/terraform.ex
+++ b/lib/terraform.ex
@@ -20,7 +20,7 @@ defmodule Terraform do
         end
       end
 
-      defp terraform(conn, terraformer) do
+      def terraform(conn, terraformer) do
         terraformer.call(conn, [])
       end
 


### PR DESCRIPTION
Overriding private functionality was deprecated, and I would like to get rid of the warning since no other viable alternative is available.